### PR TITLE
No image caption by default

### DIFF
--- a/packages/forms/resources/js/components/rich-editor.js
+++ b/packages/forms/resources/js/components/rich-editor.js
@@ -21,6 +21,8 @@ Trix.config.blockAttributes.subHeading = {
     group: false
 }
 
+Trix.config.attachments.preview.caption = { name: false, size: false }
+
 Trix.Block.prototype.breaksOnReturn = function () {
     const lastAttribute = this.getLastAttribute()
     const blockConfig = Trix.getBlockConfig(lastAttribute ? lastAttribute : 'default')


### PR DESCRIPTION
Make users able to remove image captions without showing filename and filesize